### PR TITLE
Sort projects by name or tags

### DIFF
--- a/src/components/Editor/Editor.js
+++ b/src/components/Editor/Editor.js
@@ -5,21 +5,13 @@ import "./styles.scss";
 import { Color } from "@tiptap/extension-color";
 import ListItem from "@tiptap/extension-list-item";
 import TextStyle from "@tiptap/extension-text-style";
-import {
-  BubbleMenu,
-  EditorContent,
-  EditorProvider,
-  FloatingMenu,
-  useCurrentEditor,
-  useEditor,
-} from "@tiptap/react";
+import { EditorProvider, useCurrentEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import React from "react";
 import { Button } from "@/components/ui/button";
 
 import Placeholder from "@tiptap/extension-placeholder";
 import { Image } from "@tiptap/extension-image";
-import { LoadingSpinner } from "@/components/ui/loading-spinner";
 
 //@TODO Headlines not working for some reason.
 const EditorButton = ({

--- a/src/components/Notes.js
+++ b/src/components/Notes.js
@@ -7,7 +7,7 @@ import { writeTextFile } from "@tauri-apps/api/fs";
 
 const Notes = ({ projectDirectory, projectNotesPath, almFile, setAlmFile }) => {
   const { t } = useTranslation();
-  const [notes, setNotes] = useState({});
+  const [notes, setNotes] = useState(almFile?.notes || "");
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {

--- a/src/components/Notes.js
+++ b/src/components/Notes.js
@@ -5,8 +5,7 @@ import Editor from "@/components/Editor/Editor";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import { writeTextFile } from "@tauri-apps/api/fs";
 
-const Notes = ({ projectDirectory, projectNotesPath, almFile, setAlmFile }) => {
-  const { t } = useTranslation();
+const Notes = ({ projectDirectory, almFile, setAlmFile }) => {
   const [notes, setNotes] = useState(almFile?.notes || "");
   const [loading, setLoading] = useState(false);
 

--- a/src/components/Notes.js
+++ b/src/components/Notes.js
@@ -1,6 +1,5 @@
 "use client";
 
-import { useTranslation } from "react-i18next";
 import React, { useEffect, useState } from "react";
 import Editor from "@/components/Editor/Editor";
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
@@ -20,16 +19,15 @@ const Notes = ({ projectDirectory, projectNotesPath, almFile, setAlmFile }) => {
       }
       setLoading(false);
     };
-    if (projectNotesPath && isMounted) getNotes();
+    if (almFile && isMounted) getNotes();
 
     return () => {
       isMounted = false;
     };
-  }, [projectNotesPath, almFile]);
+  }, [almFile]);
 
   const onSave = async (editedNote) => {
     // if no changes have been made we don't want to do anything
-    console.log(editedNote);
     if (editedNote === notes) return;
     setNotes(editedNote);
     const copyAlm = { ...almFile };
@@ -47,7 +45,7 @@ const Notes = ({ projectDirectory, projectNotesPath, almFile, setAlmFile }) => {
         <LoadingSpinner />
       ) : (
         <>
-          <Editor onSave={onSave} content={almFile.notes} />
+          <Editor onSave={onSave} content={notes} />
         </>
       )}
     </>

--- a/src/components/ProjectItem.js
+++ b/src/components/ProjectItem.js
@@ -42,13 +42,11 @@ export default function ProjectItem({
   filterByTags,
   config,
   setConfig,
-  setProjectDirectory,
   setFilterByTags,
   collapseAll,
 }) {
   const [openDetails, setOpenDetails] = useState(false);
   const { t } = useTranslation();
-  const [projectNotesPath, setProjectNotesPath] = useState("");
   const [almFile, setAlmFile] = useState({});
   const [isAccordionOpen, setIsAccordionOpen] = useState("open");
 
@@ -148,12 +146,7 @@ export default function ProjectItem({
             <FolderView
               project={project}
               almFile={almFile}
-              setAlmFile={setAlmFile}
-              projectNotesPath={projectNotesPath}
               handleOpenProject={handleOpenProject}
-              openDetails={openDetails}
-              setOpenDetails={setOpenDetails}
-              setProjectDirectory={setProjectDirectory}
             />
             <RightColumn
               openDetails={openDetails}
@@ -161,7 +154,6 @@ export default function ProjectItem({
               almFile={almFile}
               setAlmFile={setAlmFile}
               projectDirectory={project.path}
-              projectNotesPath={projectNotesPath}
               setOpenDetails={setOpenDetails}
             />
           </section>

--- a/src/components/ProjectItem.js
+++ b/src/components/ProjectItem.js
@@ -8,7 +8,6 @@ import { useTranslation } from "react-i18next";
 
 import { Separator } from "@/components/ui/separator";
 import FolderView from "@/components/FolderView";
-import { readTextFile } from "@tauri-apps/api/fs";
 import { Tags } from "@/components/Tags";
 import { RightColumn } from "@/components/RightColumn";
 import {
@@ -59,27 +58,7 @@ export default function ProjectItem({
 
   useEffect(() => {
     if (project) {
-      // search for notes and alm.json within project folder
-      if (project.children) {
-        const notes = project.children.filter((child) =>
-          child.name.endsWith(".md"),
-        );
-        if (notes.length > 0) setProjectNotesPath(notes[0].path);
-      }
-      const getAlmFile = async () => {
-        console.log("reading alm file");
-        const readFile = await readTextFile(project.path + "/alm.json").catch(
-          (error) => {
-            if (!error.includes("os error 2")) {
-              console.log(error);
-            }
-          },
-        );
-
-        if (!readFile) return;
-        setAlmFile(JSON.parse(readFile));
-      };
-      getAlmFile();
+      setAlmFile(project.alm);
     }
   }, [project]);
 

--- a/src/components/RightColumn.js
+++ b/src/components/RightColumn.js
@@ -18,7 +18,6 @@ import Notes from "@/components/Notes";
  */
 export const RightColumn = ({
   projectDirectory,
-  projectNotesPath,
   name,
   openDetails,
   setOpenDetails,
@@ -39,7 +38,6 @@ export const RightColumn = ({
       ) : (
         <Notes
           projectDirectory={projectDirectory}
-          projectNotesPath={projectNotesPath}
           almFile={almFile}
           setAlmFile={setAlmFile}
         />


### PR DESCRIPTION
### Description:
This PR implements two sort functions, `sortByTags` and `sortByName`, to sort projects by tags and name respectively. It also adds a dropdown menu for the user to select the sorting method.

- [x] Implemente sortByTags function to sort directory entries by tags.
- [x] Implement sortByName function to sort directory entries by name.
- [x] Added a dropdown menu for the user to select the sorting method.
